### PR TITLE
chore(ui): change wording "Working" -> "Starting"

### DIFF
--- a/bubbles-app/src/main.rs
+++ b/bubbles-app/src/main.rs
@@ -288,7 +288,7 @@ impl AsyncFactoryComponent for VmEntry {
                     set_label: match self.value.status {
                         VMStatus::NotRunning => "Stopped",
                         VMStatus::Running => "Running",
-                        VMStatus::InFlux => "Working...",
+                        VMStatus::InFlux => "Starting...",
                     }
                 },
                 append = &gtk::Button {


### PR DESCRIPTION
The VM is working when starting up, but the wording is prone to confusion.

A user might think "If it's working, why can't I open a terminal?"

So the wording for this stage is changed to "Starting" as it indicates the boot process better.